### PR TITLE
Rebuild for latest conda-forge pins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: abba8b5ce728520c3a0f1535eab19eac3c14aeef7faa5aded90017ceac2711d3
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 
@@ -21,16 +21,17 @@ requirements:
     - perl
     - pkg-config
     - harfbuzz 1.3.*
-    # FIXME: harfbuzz install everything that pango needs, but to avoid issues
+    # NOTE: harfbuzz install everything that pango needs, but to avoid issues
     # with defaults we need to pin against conda-forge versions.
-    - fontconfig 2.11.*
-    - freetype 2.6.*
+    - fontconfig 2.12.*
+    - freetype 2.7.*
     - libpng >=1.6.23,<1.7
   run:
     - harfbuzz 1.3.*
-    - fontconfig 2.11.*
-    - freetype 2.6.*
+    - fontconfig 2.12.*
+    - freetype 2.7.*
     - libpng >=1.6.23,<1.7
+
 test:
   commands:
     - pango-view --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - perl
     - pkg-config
     - harfbuzz 1.3.*
-    # NOTE: harfbuzz install everything that pango needs, but to avoid issues
+    # NOTE: harfbuzz installs everything that pango needs, but to avoid issues
     # with defaults we need to pin against conda-forge versions.
     - fontconfig 2.12.*
     - freetype 2.7.*
@@ -57,3 +57,4 @@ extra:
     - ocefpaf
     - ccordoba12
     - jakirkham
+    - pkgw


### PR DESCRIPTION
We need to bump our versions of both fontconfig and freetype.