### PR TITLE
Update to latest upstream, rebuild against new harfbuzz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,17 @@ os: osx
 osx_image: xcode6.4
 
 env:
-  matrix:
-    
-    - CONDA_PERL=5.22.2.1  CONDA_PY=27
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "SOXlOnOjZlCdyitbhZ5OLQfsbIEyYDE8l9noEUkcqtimJF/qK5Fts8t2p7WxzsBE22sdlTjZ96E/3n2RSRYT5F8kfK7LEvfaVCIuCmWudV4Od5yJTO+L7mL75/dXF3DNjhHeyTNgDGmro6HFHcZxLBSGlnl3i9z4EIzHSGyP22CuHp6rsVSX95A72Pa+Hh9vPST8/h/YzGlXEXvdPX+RL1vz1UoaC/0tIOJ/GBM0Jhy1f5QzMUZdNKxn94VJhq+sCHBZQ3AAmgENAI9qcjEln4Fo6qe5uLQ44yhoFi/qV2HFV6OwmGudZB/c71pa2NrcAV1QkOIH2o+yUNZRVXs2aughroPOv1uR9Re5hrcBtWn8yfD3vnAKWlBn1oiB1iwzGWZ5eqFqJsGvd+I4Q0YUiIAjsw40WHpeU/wtFRTTgnbQL9QWiQ2FWrGbjQpI6jsWqF8DWQnUcuESTYAoMDsM1pUK2RvZyXp6jS/1FFQapi5B0Zzt4kbVFQBwMPBoTdWlCT4kT5zk1ps06aXAX3wgikyu4unHotPeZRmYW0VETO8IN8EA81oIZP28qIqL/6Cs5T71y4Z6RJ4nBufMN7KVAAk6tSkjKlmfOKLSxa7NCEi03mbmzuXXOufVgLonToV831ltpVQ7t7kLbB+UMEXFbAgOza4rCzhplWeEKc/9svk="
 
 
 before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
     # Remove homebrew.
     - |
       echo ""

--- a/ci_support/fast_finish_ci_pr_build.sh
+++ b/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,12 +24,14 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
-                        bash || exit $?
+                        bash || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1
@@ -48,4 +50,11 @@ source run_conda_forge_build_setup
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+set -x
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set major = "1.40" %}
-{% set patch = "3" %}
+{% set patch = "4" %}
 {% set version = major + "." + patch %}
 
 package:
@@ -9,18 +9,18 @@ package:
 source:
   url: http://ftp.gnome.org/pub/GNOME/sources/pango/{{ major }}/pango-{{ version }}.tar.xz
   fn: pango-{{ version }}.tar.xz
-  sha256: abba8b5ce728520c3a0f1535eab19eac3c14aeef7faa5aded90017ceac2711d3
+  sha256: f8fdc5fc66356dc4edf915048cceeee065a0e0cb70b3b2598f62bda320129a3e
 
 build:
-  number: 3
-  skip: True  # [win or py3k]
+  number: 0
+  skip: true  # [win or py3k]
   detect_binary_files_with_prefix: true
 
 requirements:
   build:
     - perl 5.22.2.1
     - pkg-config
-    - harfbuzz 1.3.*
+    - harfbuzz 1.4.*
     # NOTE: harfbuzz installs everything that pango needs, but to avoid issues
     # with defaults we need to pin against conda-forge versions.
     - fontconfig 2.12.*
@@ -29,7 +29,7 @@ requirements:
     - python >=2.7,<3  # [not win]
     - libpng >=1.6.28,<1.7
   run:
-    - harfbuzz 1.3.*
+    - harfbuzz 1.4.*
     - fontconfig 2.12.*
     - freetype 2.7|2.7.*
     - libpng >=1.6.28,<1.7
@@ -37,8 +37,8 @@ requirements:
 test:
   commands:
     - pango-view --help
-    - conda inspect linkages -p $PREFIX pango  # [not win]
-    - conda inspect objects -p $PREFIX pango  # [osx]
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
   home: http://www.pango.org/


### PR DESCRIPTION
Update to a marginally newer upstream release and start building against the `1.4.x` series of `harfbuzz`.