### PR TITLE
Require cairo

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,5 +1,7 @@
 c_compiler:
 - toolchain_c
+cairo:
+- '1.14'
 fontconfig:
 - '2.13'
 freetype:
@@ -11,6 +13,8 @@ libpng:
 perl:
 - '5.26'
 pin_run_as_build:
+  cairo:
+    max_pin: x.x
   fontconfig:
     max_pin: x
   freetype:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 c_compiler:
 - toolchain_c
+cairo:
+- '1.14'
 fontconfig:
 - '2.13'
 freetype:
@@ -17,6 +19,8 @@ macos_min_version:
 perl:
 - '5.26'
 pin_run_as_build:
+  cairo:
+    max_pin: x.x
   fontconfig:
     max_pin: x
   freetype:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 90af1beaa7bf9e4c52db29ec251ec4fd0a8f2cc185d521ad1f88d01b3a6a17e3
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - python >=2.7,<3  # [not win]
     - {{ compiler('c') }}
   host:
+    - cairo
     - harfbuzz
     # NOTE: harfbuzz installs everything that pango needs, but to avoid issues
     # with defaults we need to pin against conda-forge versions.
@@ -31,6 +32,7 @@ requirements:
     - gobject-introspection  # [not win]
     - libpng
   run:
+    - cairo
     - harfbuzz
     - fontconfig
     - freetype


### PR DESCRIPTION
Makes `cairo` a dependency of `pango`, which [LFS recommends]( http://www.linuxfromscratch.org/blfs/view/8.1/x/pango.html ) and appears to be needed for our [`gtk2` macOS build]( https://travis-ci.org/conda-forge/gtk2-feedstock/builds/402329020#L663-L665 ).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
