### PR TITLE
Remove Libtool `.la` files

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -5,7 +5,7 @@ fontconfig:
 freetype:
 - 2.8.1
 harfbuzz:
-- '1.7'
+- '1'
 libpng:
 - 1.6.34
 perl:
@@ -16,8 +16,8 @@ pin_run_as_build:
   freetype:
     max_pin: x.x
   harfbuzz:
-    max_pin: x.x
+    max_pin: x
   libpng:
     max_pin: x.x
   perl:
-    max_pin: x.x
+    max_pin: x.x.x

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -7,7 +7,7 @@ fontconfig:
 freetype:
 - 2.8.1
 harfbuzz:
-- '1.7'
+- '1'
 libpng:
 - 1.6.34
 macos_machine:
@@ -22,8 +22,8 @@ pin_run_as_build:
   freetype:
     max_pin: x.x
   harfbuzz:
-    max_pin: x.x
+    max_pin: x
   libpng:
     max_pin: x.x
   perl:
-    max_pin: x.x
+    max_pin: x.x.x

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,11 @@ if [ $(uname) == Darwin ] ; then
     export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"
 fi
 
+# Cf. https://github.com/conda-forge/staged-recipes/issues/673, we're in the
+# process of excising Libtool files from our packages. Existing ones can break
+# the build while this happens.
+find $PREFIX -name '*.la' -delete
+
 ./configure --prefix=$PREFIX \
             --with-xft \
             --with-cairo=$PREFIX
@@ -35,3 +40,7 @@ make
 # FAIL test-layout (exit status: 133)
 # make check
 make install
+
+# Remove any new Libtool files we may have installed. It is intended that
+# conda-build will eventually do this automatically.
+find $PREFIX -name '*.la' -delete

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 90af1beaa7bf9e4c52db29ec251ec4fd0a8f2cc185d521ad1f88d01b3a6a17e3
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
Pursuant to https://github.com/conda-forge/staged-recipes/issues/673 and https://github.com/conda-forge/libxcb-feedstock/pull/9, we're going to remove these files from our packages. Eventually conda-build will do this automatically for us, but for now we take care of it manually. We need to delete the files both before the build (because inconsistent complements of `.la` files can break the build) and after (because we may have installed new ones).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
