### PR TITLE
Update to upstream 1.42.4.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set major = "1.40" %}
-{% set patch = "14" %}
+{% set major = "1.42" %}
+{% set patch = "4" %}
 {% set version = major + "." + patch %}
 
 package:
@@ -8,10 +8,10 @@ package:
 
 source:
   url: http://ftp.gnome.org/pub/GNOME/sources/pango/{{ major }}/pango-{{ version }}.tar.xz
-  sha256: 90af1beaa7bf9e4c52db29ec251ec4fd0a8f2cc185d521ad1f88d01b3a6a17e3
+  sha256: 1d2b74cd63e8bd41961f2f8d952355aa0f9be6002b52c8aa7699d9f5da597c9d
 
 build:
-  number: 1005
+  number: 0
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 
@@ -25,6 +25,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - cairo
+    - fribidi
     - harfbuzz
     # NOTE: harfbuzz installs everything that pango needs, but to avoid issues
     # with defaults we need to pin against conda-forge versions.
@@ -34,6 +35,7 @@ requirements:
     - libpng
   run:
     - cairo
+    - fribidi
     - harfbuzz
     - fontconfig
     - freetype


### PR DESCRIPTION
An experiment to see how hard this might be. It looks like fribidi is going to limit us on platforms besides macOS and Linux (for the time being).

* [x] Used a fork of the feedstock to propose changes
* [x] Reset the build number to `0` (the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.