### PR TITLE
Need to remove -lm from pc file on Win to fix downstream linking.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,12 @@ package:
 source:
   url: http://ftp.gnome.org/pub/GNOME/sources/pango/{{ major }}/pango-{{ version }}.tar.xz
   sha256: 1d2b74cd63e8bd41961f2f8d952355aa0f9be6002b52c8aa7699d9f5da597c9d
+  patches:
+    # pc file patch should not be needed for version 1.43+
+    - windows_fix_libm_in_pc_file.patch  # [win]
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win and vc<14]
   detect_binary_files_with_prefix: true
 

--- a/recipe/windows_fix_libm_in_pc_file.patch
+++ b/recipe/windows_fix_libm_in_pc_file.patch
@@ -1,0 +1,6 @@
+--- a/pango.pc.in
++++ b/pango.pc.in
+@@ -11,3 +11,2 @@
+ Libs: -L${libdir} -lpango-@PANGO_API_VERSION@
+-Libs.private: -lm
+ Cflags: -I${includedir}/pango-1.0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This one's pretty simple: the pkgconfig file has a "-lm" flag that shouldn't be there on Windows and can break downstream builds (in this case, `librsvg`). Practically any newer version of `pango` scraps this pc file template in favor of generating it via meson, so this patch shouldn't be needed moving into the future.