### PR TITLE
Fix Windows build by pinning meson to 0.53.2.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ build:
 requirements:
   build:
     - make  # [not win]
-    - meson  # [win]
+    # see https://github.com/conda-forge/meson-feedstock/issues/30
+    - meson 0.53.2  # [win]
     - ninja  # [win]
     - perl  # [not win]
     - pkg-config


### PR DESCRIPTION
See https://github.com/conda-forge/meson-feedstock/issues/30

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
At some point between pull request and merge of #31, conda-forge upgraded to `meson=0.54.0` which broke the Windows build. This is something that's been seen with `meson` for other packages (see https://github.com/conda-forge/meson-feedstock/issues/30), and the easy workaround is to pin to the earlier `meson` version.