### PR TITLE
recipe/build.sh: fix typo in cross-build script

### DIFF
--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 cairo:
 - '1.16'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,8 +41,8 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
     export CC=$CC_FOR_BUILD
     export CXX=$CXX_FOR_BUILD
     export OBJC=$OBJC_FOR_BUILD
-    export AR=($CC_FOR_BUILD -print-prog-name=ar)
-    export NM=($CC_FOR_BUILD -print-prog-name=nm)
+    export AR="$($CC_FOR_BUILD -print-prog-name=ar)"
+    export NM="$($CC_FOR_BUILD -print-prog-name=nm)"
     export LDFLAGS=${LDFLAGS//$PREFIX/$BUILD_PREFIX}
     export PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 21e1f5798bcdfda75eabc4280514b0896ab56f656d4e7e66030b9a2535ecdc98
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   ignore_run_exports_from:
     - {{ compiler('cxx') }}


### PR DESCRIPTION
When trying to get the latest librsvg to build, I noticed a typo in our boilerplate gobject-introspection+cross-build scripts. I guess it's not actually fatal most of the time, but we should still fix it.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
